### PR TITLE
Update Medium link for CNN speedup blog post

### DIFF
--- a/2020/12/28/speedup-your-cnn-using-fast-dense-feature-extraction-and-pytorch/index.html
+++ b/2020/12/28/speedup-your-cnn-using-fast-dense-feature-extraction-and-pytorch/index.html
@@ -246,7 +246,7 @@ unicode-range: U+F004-F005,U+F007,U+F017,U+F022,U+F024,U+F02E,U+F03E,U+F044,U+F0
 
 
 
-<p><a href="https://towardsdatascience.com/speedup-your-cnn-using-fast-dense-feature-extraction-and-pytorch-dc32acbf12ef">The full story is available Medium</a></p>
+<p><a href="https://medium.com/data-science/speedup-your-cnn-using-fast-dense-feature-extraction-and-pytorch-dc32acbf12ef">The full story is available on Medium</a></p>
 </div>
 <div id="comments" class="comments-area">
 		<div id="respond" class="comment-respond">


### PR DESCRIPTION
### Motivation
- Fix the external link and anchor text in the CNN speedup blog post so it points to the canonical Medium Data Science URL and reads correctly.

### Description
- Replaced the `towardsdatascience.com` URL with `https://medium.com/data-science/speedup-your-cnn-using-fast-dense-feature-extraction-and-pytorch-dc32acbf12ef` and updated the anchor text to "The full story is available on Medium" in `2020/12/28/speedup-your-cnn-using-fast-dense-feature-extraction-and-pytorch/index.html`.

### Testing
- Verified the change with `rg` to confirm the new text and URL, served the site with `python -m http.server`, captured a Playwright screenshot of the updated page, and committed the change with the message `Update Medium link for CNN speedup post`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb2bfc3fc832d82801c20c71b37b5)