### PR TITLE
Update Medium link in image restoration post

### DIFF
--- a/2020/12/28/how-to-perform-image-restoration-absolutely-dataset-free/index.html
+++ b/2020/12/28/how-to-perform-image-restoration-absolutely-dataset-free/index.html
@@ -250,7 +250,7 @@ unicode-range: U+F004-F005,U+F007,U+F017,U+F022,U+F024,U+F02E,U+F03E,U+F044,U+F0
 
 
 
-<p><a href="https://towardsdatascience.com/how-to-perform-image-restoration-absolutely-dataset-free-d08da1a1e96d">The full story is available Medium</a></p>
+<p><a href="https://medium.com/data-science/how-to-perform-image-restoration-absolutely-dataset-free-d08da1a1e96d">The full story is available on Medium</a></p>
 </div>
 <div id="comments" class="comments-area">
 		<div id="respond" class="comment-respond">


### PR DESCRIPTION
### Motivation
- Ensure the article links to the requested canonical Medium Data Science URL and clarify the anchor text.

### Description
- Replaced the old Towards Data Science URL with `https://medium.com/data-science/how-to-perform-image-restoration-absolutely-dataset-free-d08da1a1e96d` and updated the anchor text to "The full story is available on Medium" in `2020/12/28/how-to-perform-image-restoration-absolutely-dataset-free/index.html`.

### Testing
- Verified the updated URL and anchor text using `rg -n "full story|medium.com/data-science" 2020/12/28/how-to-perform-image-restoration-absolutely-dataset-free/index.html`, which located the changed line successfully.
- Served the site locally with `python3 -m http.server 8000` and captured a full-page screenshot to confirm the change rendered correctly, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb2e32728832d92e2e835a3cc5a36)