### PR TITLE
Remove pie chart from About page skills section

### DIFF
--- a/about-2/index.html
+++ b/about-2/index.html
@@ -443,12 +443,6 @@ unicode-range: U+F004-F005,U+F007,U+F017,U+F022,U+F024,U+F02E,U+F03E,U+F044,U+F0
 
 
 
-<div class="wp-block-column is-vertically-aligned-center is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:28%">
-<figure class="wp-block-image size-large is-resized is-style-default"><img decoding="async" src="./../wp-content/uploads/2020/12/pie-7.png" alt="" class="wp-image-380" width="315" height="288"/></figure>
-</div>
-
-
-
 <div class="wp-block-column is-vertically-aligned-center is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:16.75%">
 <h2 class="wp-block-heading">Part Developer</h2>
 


### PR DESCRIPTION
### Motivation
- Remove the pie-chart image block from the “Part Researcher / Part Developer” row on the About page to simplify the layout and focus on the text columns.

### Description
- Deleted the `<figure>` image and its surrounding column (the `pie-7.png` block) from `about-2/index.html` and left the adjacent researcher and developer columns intact.

### Testing
- Ran `rg -n "pie-7.png" about-2/index.html` to confirm the image reference is gone and it reported the pie chart was removed (success).
- Attempted to capture a browser screenshot with Playwright, but the Chromium process crashed with a SIGSEGV in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb4571bac832da332f7f34dcc8e0d)